### PR TITLE
exclusao de log de mensagem de envio e log de codigo hash

### DIFF
--- a/Services/notifications/SNS.js
+++ b/Services/notifications/SNS.js
@@ -26,8 +26,6 @@ module.exports = class SNS {
             const now = new Date()
             const randomId = Math.floor(new Date().valueOf() + (Math.random() * Math.random()));
 
-            console.log(Date.now().toString(36))
-
             payload.QueueMonitorId = randomId;
 
             this.sns.publish({
@@ -43,8 +41,6 @@ module.exports = class SNS {
                     BRCAPAWS.S3_Put(bucketQueueMonitor, path+randomId.toString(), payload, function (err, s3Data) {
                         if (err) {
                             console.log(err);
-                        } else {
-                            console.log("BRCAP-AWS: dados gravados no S3.");
                         }
                     });
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brcap-aws",
-  "version": "1.8.28",
+  "version": "1.8.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11,7 +11,7 @@
       "requires": {
         "buffer": "4.9.1",
         "crypto-browserify": "1.0.9",
-        "events": "1.1.1",
+        "events": "^1.1.1",
         "jmespath": "0.15.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
@@ -31,9 +31,9 @@
       "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.12",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "cluster-key-slot": {
@@ -101,9 +101,9 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
       "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
       "requires": {
-        "double-ended-queue": "2.1.0-0",
-        "redis-commands": "1.3.5",
-        "redis-parser": "2.6.0"
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
       }
     },
     "redis-clustr": {
@@ -111,9 +111,9 @@
       "resolved": "https://registry.npmjs.org/redis-clustr/-/redis-clustr-1.6.0.tgz",
       "integrity": "sha512-a7pt7y8qLCHUPIHB2nprQfprkrYUrzpdxkzmNIaJAwCrdn5wJPDaDr6j+2EAZoMfXYMiwxehPOCFLgi8Z171mw==",
       "requires": {
-        "cluster-key-slot": "1.0.12",
-        "denque": "1.3.0",
-        "redis": "2.8.0"
+        "cluster-key-slot": "^1.0.5",
+        "denque": "^1.1.0",
+        "redis": "^2.6.0"
       }
     },
     "redis-commands": {
@@ -155,8 +155,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
       "requires": {
-        "sax": "1.2.1",
-        "xmlbuilder": "4.2.1"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "^4.1.0"
       }
     },
     "xmlbuilder": {
@@ -164,7 +164,7 @@
       "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
       "requires": {
-        "lodash": "4.17.11"
+        "lodash": "^4.0.0"
       }
     }
   }


### PR DESCRIPTION
Exclusão dos logs de hash e aviso de notificação de mensagem.
Não é mais necessário logar isso já que as mensagens estão sendo enviadas para o s3 e conseguimos baixá-las sem problemas com a modificação de versionamento que foi criada.