### PR TITLE
feature(retry): estrategia de reenvio de msgs SNS

### DIFF
--- a/Services/notifications/RetrySNS.js
+++ b/Services/notifications/RetrySNS.js
@@ -1,0 +1,79 @@
+const createRepository = require('../storage/LocalStorage');
+const {
+    to,
+    sleep,
+    createLog,
+    getExponentialBackoff, 
+} = require('../../utils')
+
+const diretory = 'app/local-storage';
+const info = console.log.bind(null, '[brcap-aws] - ')
+
+const defaultObject = {
+    maxRetries:5,
+    startTime: 15,
+    dir:diretory,
+    bufferMaxLimit: 3000
+}
+
+module.exports = class RetrySNS {
+    constructor({
+        maxRetries=5,
+        bufferMaxLimit=1500,
+        startTime=15,
+        logging,
+        dir=diretory,
+        sns
+    } = defaultObject) {
+        this.sns = sns
+        this.maxRetries = maxRetries;
+        this.retryCounter = 0;
+        this.timer = null;
+        this.repository = createRepository({ 
+            bufferMaxLimit,
+            logging, 
+            dir
+        })
+        this.handleRetryStrategy = getExponentialBackoff.bind(null, startTime);
+    }
+
+   async saveError(data,opts={attempt: 0}) {
+        info(
+            `Notificao de sns encontrou um erro. Reenvio em ${this.startTime}s`
+        );
+        clearTimeout(this.timer)
+        this.timer = this.retryScheduler(opts.attempt);
+        await this.repository.save(data);
+    }
+
+    async retry() {       
+       for await (const { key, messages, done } of this.repository.pull()) {
+            if(done) {
+                info('Mensagens reenviadas')
+                break;
+            }
+            const map = new Map(messages);
+            try {
+                for await(const [keyMap,data] of map.entries()) {
+                    await this.sns.publish(data).promise();
+                    map.delete(keyMap);
+                }
+                await this.repository.clean(key, map)
+            } catch (error) {
+                info('Ocorreu um erro durante reenvio. Tentando novamente')
+                await this.saveError(map, { attempt: ++this.retryCounter })
+                break;
+            }
+       }
+    }
+
+    retryScheduler(attempt=0) {
+        if(this.maxRetries >= attempt) {
+            return global.setTimeout(
+                this.retry.bind(this), 
+                this.handleRetryStrategy(attempt)
+            );
+        }
+        this.retryCounter = 0;
+    }  
+}

--- a/Services/storage/LocalStorage.js
+++ b/Services/storage/LocalStorage.js
@@ -1,0 +1,83 @@
+const storage = require('node-persist');
+const { v4: uuidv4 } = require('uuid');
+
+const { sleep, createLog } = require('../../utils')
+
+class Repository {
+    constructor(config) {
+        this.inMemoryData = new Map();
+        this.bufferMaxLimit = config.bufferMaxLimit;
+        this.key = 1n;
+    }
+
+    createStorage(config) {
+        storage.init(config)
+            .then(result => {
+                console.log(`[brcap-aws] Local storage created at \x1b[32m${result.dir}\x1b[0m`)
+            })
+            .catch(error => 
+                console.log(`No local storage was created duo to some error: ${error.message}`)
+            )
+        return this;
+    }
+
+    async save(data) {
+        this.inMemoryData = (data instanceof Map) 
+            ? new Map([...this.inMemoryData, ...data])
+            : this.inMemoryData.set(uuidv4(),data);
+        
+        if(this.inMemoryData.size > this.bufferMaxLimit) {
+            await this.pushToFileSystem();
+        }
+    }
+
+    async pushToFileSystem() {
+        await storage.setItem(`${this.key}`, Object.fromEntries([...this.inMemoryData]));
+        this.inMemoryData.clear();
+        this.key++;
+    }
+
+    async *pull() {
+        const fsKeys = await storage.keys();
+        while(this.inMemoryData.size || fsKeys.length) {
+            // pull out from memory (Buffer)
+            if(this.inMemoryData.size) {
+                const data = { 
+                    key: "0", // position 0 reserved for memory access
+                    messages: [...this.inMemoryData], 
+                    done:false 
+                };
+                this.inMemoryData.clear();
+                yield data;
+                continue;
+            }
+            // pull out from filesystem
+            const filesystemMessages = await storage.getItem(fsKeys[0]);
+            const fsData =  {
+                key: fsKeys[0],
+                messages: Object.entries(filesystemMessages),
+                done:false
+            }
+            await storage.removeItem(fsKeys[0]);
+            fsKeys.shift()
+            yield fsData;
+        }
+        yield { done: true };
+    }
+
+    async updateOnFail(key, messagesMap, isNecessaryIO=true) {
+        if(key === '0') {
+            return this.inMemoryData = new Map([...this.inMemoryData, ...messagesMap])
+        }
+        if(isNecessaryIO) {
+           await storage.updateItem(key, Object.fromEntries([...messagesMap]));
+        }
+    }
+
+     async clean(key, map) {
+        if(key === '0') return;
+        await storage.removeItem(key);
+    }
+}
+
+module.exports = (config) =>  new Repository(config).createStorage(config);

--- a/Services/storage/S3.js
+++ b/Services/storage/S3.js
@@ -1,59 +1,55 @@
 // Load the AWS SDK for Node.js
-var AWS = require('aws-sdk');
+const AWS = require('aws-sdk');
+const { isInvalidInput } = require('../../utils');
 
-var s3;
+const s3 = new AWS.S3({apiVersion: '2006-03-01'});
 
 module.exports = class S3 {
 
     constructor() {
-        this.s3 = new AWS.S3();
+        this.s3 = s3;
     }
 
-    get(bucket, key, callback) {
-        if (bucket === undefined || bucket === null || bucket === '') {
-            callback("bucket missing or in a invalid state.", null);
-        } else if (key === undefined || key === null || key === '') {
-            callback("key missing or in a invalid state.", null);
-        } else {
-            var params = {
-                Bucket: bucket,
-                Key: key
-            };
-            this.s3.getObject(params, function (err, data) {
-                callback(err, data);
-            });
+    get(bucket, key) {
+        if(isInvalidInput([bucket, key])) {
+            return Promise.reject("bucket or key missing or in a invalid state.")
         }
+
+        return this.s3.getObject({
+            Bucket: bucket,
+            Key: key
+        }).promise();
     }
 
-    put(bucket, key, param, callback) {
+    put(bucket, key, param) {
         const params = {
             Bucket: bucket,
             Key: key,
             Body: JSON.stringify(param)
         };
-        this.s3.putObject(params, (err, data) => callback(err, data));
+       return this.s3.putObject(params).promise();
     }
 
-    putObject(params, callback) {
-        this.s3.putObject(params, (err, data) => callback(err, data));
+    putObject(params) {
+        return this.s3.putObject(params).promise();
     }
 
-    upload(params, callback) {
-        this.s3.upload(params, (err, data) => callback(err, data));
+    upload(params) {
+        return this.s3.upload(params).promise();
     }
 
-    delete(bucket, pathFileName, callback) {
+    delete(bucket, pathFileName) {
         const params = {
             Bucket: bucket,
             Key: pathFileName,
         };
-        this.s3.deleteObject(params, (err, data) => callback(err, data));
+        return this.s3.deleteObject(params).promise();
     }
 
-    listObjects(bucket, directory, callback) {
-        this.s3.listObjectsV2({
+    listObjects(bucket, directory) {
+       return this.s3.listObjectsV2({
             Bucket: bucket,
             Prefix: directory,
-        }, callback);
+        }).promise();
     }
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
-var SNS = require("./Services/notifications/SNS");
-var SQS = require("./Services/notifications/SQS");
-var Redis = require("./Services/cache/Redis");
-var S3 = require("./Services/storage/S3");
-var Dynamo = require("./Services/DataBase/DynamoDB");
-var KMS = require("./Services/secret/Kms");
+require('./pollyfill');
+
+const SNS = require("./Services/notifications/SNS");
+const SQS = require("./Services/notifications/SQS");
+const Redis = require("./Services/cache/Redis");
+const S3 = require("./Services/storage/S3");
+const Dynamo = require("./Services/DataBase/DynamoDB");
+const KMS = require("./Services/secret/Kms");
 
 const {
   getIndex,
@@ -17,9 +19,18 @@ const {
 } = require("./Services/search/ElasticSearch");
 
 exports.SNS_Post = function(snsURL, payload, subject, region, callback) {
-  new SNS(region).post(snsURL, payload, subject, function(err, data) {
+  new SNS(region).post(snsURL, payload, subject)
+    .then(data => callback(null, data))
+    .catch(error => callback(error, null))
+};
+
+exports.snsPostPromise = 
+  async (snsURL, payload, subject, region) => 
+    new SNS(region).post(snsURL, payload, subject)
+exports.SNS_ListSubscriptionByTopic = function(snsURL, region, callback){
+  new SNS(region).listSubscriptionsByTopic(snsURL, function(err, data){
     callback(err, data);
-  });
+    });
 };
 
 exports.SNS_ListSubscriptionByTopic = function(snsURL, region, callback){
@@ -86,36 +97,52 @@ exports.Redis_Delete = function(key, host, port, callback) {
 };
 
 exports.S3_Get = function(bucket, key, callback) {
-  new S3().get(bucket, key, function(err, data) {
-    callback(err, data);
-  });
+  new S3().get(bucket, key)
+    .then(data => callback(null, data))
+    .catch(error => callback(error, null))
 };
+
+exports.s3GetPromise = async(bucket,key) => new S3().get(bucket,key)
 
 exports.S3_Put = function(bucket, key, param, callback) {
-  new S3().put(bucket, key, param, function(err, data) {
-    callback(err, data);
-  });
+  new S3().put(bucket, key, param)
+    .then(data => callback(null, data))
+    .catch(error => callback(error, null))
 };
+
+exports.s3PutPromise = async(bucket, key, param) => new S3().put(bucket, key, param)
 
 exports.S3_PutObject = function(param, callback) {
-  new S3().putObject(param, function(err, data) {
-    callback(err, data);
-  });
+  new S3().putObject(param)
+    .then(data => callback(null, data))
+    .catch(error => callback(error, null))
 };
+
+exports.s3PutObjectPromise = async(param) => new S3().putObject(param)
 
 exports.S3_Upload = function(param, callback) {
-  new S3().upload(param, callback);
+  new S3().upload(param)
+    .then(data => callback(null, data))
+    .catch(error => callback(error, null))
 };
+
+exports.s3UploadPromise = async(param) =>  new S3().upload(param);
 
 exports.S3_DeleteObject = function (bucket, pathFileName, callback) {
-  new S3().delete(bucket, pathFileName, function (err, data) {
-    callback(err, data);
-  });
+  new S3().delete(bucket, pathFileName)
+    .then(data => callback(null, data))
+    .catch(error => callback(error, null))
 };
 
+exports.s3DeleteObject = async(bucket, pathFileName) => new S3().delete(bucket, pathFileName)
+
 exports.S3_ListObjects = function (bucket, directory, callback) {
-  new S3().listObjects(bucket, directory, callback);
+  new S3().listObjects(bucket, directory)
+    .then(data => callback(null, data))
+    .catch(error => callback(error, null))
 };
+
+exports.s3ListObjects = async(bucket, directory) => new S3().listObjects(bucket, directory)
 
 exports.Dynamo_Delete = function(object, region, callback) {
   new Dynamo(region).delete(object, function(err, data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,13 @@
         "uuid": "3.1.0",
         "xml2js": "0.4.17",
         "xmlbuilder": "4.2.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+        }
       }
     },
     "base64-js": {
@@ -46,6 +53,14 @@
       "resolved": "http://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
       "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA="
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "denque": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.3.0.tgz",
@@ -55,6 +70,34 @@
       "version": "2.1.0-0",
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
+    "es-abstract": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
     },
     "events": {
       "version": "1.1.1",
@@ -66,10 +109,54 @@
       "resolved": "https://registry.npmjs.org/forEachAsync/-/forEachAsync-3.0.0.tgz",
       "integrity": "sha1-NHWpWnfk3C0oAJE+aCTed7AM2Ao="
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+    },
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
       "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+    },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+    },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -82,9 +169,62 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "mkdirp": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
+      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "node-persist": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-3.0.5.tgz",
+      "integrity": "sha512-zJmBA58kI9QAxXLMc4NLswgzXVIqKfsfQtiySMF6eEQ3kVvoM3YHzcP0//L9u30Fqx3cYe1FL/a+fyB3VwO/oQ==",
+      "requires": {
+        "mkdirp": "~0.5.1"
+      }
+    },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
     },
     "punycode": {
       "version": "1.3.2",
@@ -131,6 +271,24 @@
       "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
     "tiny-json-http": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/tiny-json-http/-/tiny-json-http-7.0.2.tgz",
@@ -146,9 +304,9 @@
       }
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+      "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
     },
     "xml2js": {
       "version": "0.4.17",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,11 @@
   "dependencies": {
     "aws-sdk": "2.176.0",
     "forEachAsync": "^3.0.0",
+    "node-persist": "^3.0.5",
+    "object.fromentries": "^2.0.2",
     "redis": "^2.8.0",
     "redis-clustr": "^1.6.0",
-    "tiny-json-http": "^7.0.0"
+    "tiny-json-http": "^7.0.0",
+    "uuid": "^7.0.2"
   }
 }

--- a/pollyfill.js
+++ b/pollyfill.js
@@ -1,0 +1,5 @@
+const fromEntries = require('object.fromentries');
+
+if (!Object.fromEntries) {
+    fromEntries.shim();
+}

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,25 @@
+module.exports = {
+    isInvalidInput(inputs=[]) {
+        return inputs.some(condition => [null, undefined, ''].includes(condition));
+    },
+    sleep(timeInSeconds) {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve();
+            }, timeInSeconds*1000)
+        })
+    },
+    getExponentialBackoff(startTimeInSeconds,attempts) {
+        return Math.pow(2, attempts) * (startTimeInSeconds * 1000);
+    },
+    createLog(logging=false) {
+        return logging 
+            ? (logMessage) => console.log(logMessage)
+            : _ => _
+    },
+    to(promise) {
+        return promise
+                .then(data => [null, data])
+                .catch(error => [error])
+    }
+}


### PR DESCRIPTION
### Descricao da nova funcionalidade

A ideia era ao ocorrer algum tipo de erro no cliente que envia as msgs (brca-aws) no caso.
possibilitar o reenvio dessas mensagens de uma maneira exponencial e limitada a 5 tentativas.

ainda nao consegui abrir a api para customizacao dessa estrategia de reenvio como mudanca da quantidade de tentativas, volume do buffer (antes de fazer i/o com a dep local-storage).

A estrategia consiste em ao ocorrer um erro, agendamos uma estrategia e reenvio para daqui a x segundos (tempo default de 15) e chegando outra mensagem de erro dentro desse periodo, é feito um novo reagendamento para daqui a 15 segundos novamente...ate que o ciclo termine...entao apos 15s é executada a funcao de reenvio, que eventualmente pode ocorrer erro ao tentar enviar. Nesta cituacao incrementamos o numero de tentativas e portanto uma novo agendamento é feito, porem agora com uma janela de 30s e por ai vai se nao conseguir resolver agenda pra 1 min, 2 min, 4 min, 8 min e por fim 16 min.

se neste tempo nao houver solucacao a msg deve ser excluida e logada

A principio a feature é experimental e sera usada somente por um grupo pequeno de usuarios.
logo o PR para a branch criada pela arquietura com essa premissa.

Houveram mudancas na Api e suporte a promise (somente sns e s3) porem sem quebrar api antiga para no futuro em uma versao 2.0 da lib essa feature e o suporte full a promises. 

### Requisitos

- Node 10.3.0+
